### PR TITLE
Fix culvert result property names

### DIFF
--- a/src/pages/CulvertSizingForm.js
+++ b/src/pages/CulvertSizingForm.js
@@ -763,16 +763,17 @@ const CulvertSizingForm = () => {
     
     // Create enhanced calculationResults object
     const calculationResults = {
-      recommendedSize: results.selectedPipeSize,
+      // finalSize is the overall recommended pipe size from the calculator
+      recommendedSize: results.finalSize,
       shape: "Circular",
       material: formValues.pipeRoughness === "0.024" ? "Corrugated Metal Pipe (CMP)" : 
                formValues.pipeRoughness === "0.012" ? "Smooth HDPE" : "Concrete",
       manningsN: parseFloat(formValues.pipeRoughness),
       hwdCriterion: `HW/D ≤ ${formValues.maxHwdRatio}`,
       climateChangeFactor: 1.20, // Assuming climate factor of 1.2
-      governingMethod: "Hydraulic Calculation (Manning's)",
-      californiaMethodSize: results.californiaMethodSize || results.selectedPipeSize,
-      hydraulicCalculationSize: results.selectedPipeSize,
+      governingMethod: results.governingMethod,
+      californiaMethodSize: results.californiaSize,
+      hydraulicCalculationSize: results.hydraulicSize,
       bankfullArea: parseFloat(results.streamArea),
       endArea: parseFloat(results.requiredCulvertArea),
       designDischarge: parseFloat(results.bankfullFlow),

--- a/src/screens/culvert/ResultScreen.js
+++ b/src/screens/culvert/ResultScreen.js
@@ -36,12 +36,10 @@ const CulvertResultScreen = () => {
   }
 
   // Determine the governing method and final recommendation
-  const californiaSize = results.selectedPipeSize;
-  const hydraulicSize = results.hydraulicUpsizedPipeSize;
-  const finalSize = hydraulicSize > californiaSize ? hydraulicSize : californiaSize;
-  const governingMethod = hydraulicSize > californiaSize ? 
-    "Hydraulic Calculation (Manning's)" : 
-    "California Method";
+  const californiaSize = results.californiaSize;
+  const hydraulicSize = results.hydraulicSize;
+  const finalSize = results.finalSize;
+  const governingMethod = results.governingMethod;
   
   // Extract form values from location state
   const formValues = location.state?.formValues || {};


### PR DESCRIPTION
## Summary
- map culvert calculation results to correct keys
- use correct field names in `ResultScreen`

## Testing
- `npm test` *(fails: react-scripts not found)*